### PR TITLE
Move Skills Section Content to CMS and Add Chakra UI Logo

### DIFF
--- a/assets/icons/chakraui.svg
+++ b/assets/icons/chakraui.svg
@@ -1,0 +1,10 @@
+<svg width="582" height="582" viewBox="0 0 582 582" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="582" height="582" rx="291" fill="url(#paint0_linear)"/>
+<path d="M157.521 303.421L355.881 106.426C359.587 102.746 365.55 107.225 363.049 111.809L289.22 247.123C287.573 250.141 289.758 253.821 293.196 253.821H420.782C424.892 253.821 426.877 258.857 423.872 261.661L200.293 470.326C196.284 474.067 190.317 468.796 193.536 464.356L299.373 318.351C301.543 315.357 299.404 311.164 295.706 311.164H160.713C156.67 311.164 154.653 306.27 157.521 303.421Z" fill="white"/>
+<defs>
+<linearGradient id="paint0_linear" x1="291" y1="0" x2="291" y2="582" gradientUnits="userSpaceOnUse">
+<stop stop-color="#7BCBD4"/>
+<stop offset="1" stop-color="#29C6B7"/>
+</linearGradient>
+</defs>
+</svg>

--- a/components/molecules/SkillCard.vue
+++ b/components/molecules/SkillCard.vue
@@ -2,7 +2,7 @@
   div(class='flex flex-col items-center lg:w-[369px]')
     div(class='flex mb-3 flex-center')
       A-Icon(
-        v-for='(logo, index) in skill.logos'
+        v-for='(logo, index) in skill.tags'
         :key='index'
         :icon='logo'
         isLarge
@@ -10,7 +10,7 @@
       )
     A-Heading(
       tag='h3'
-      :content="skill.heading"
+      :content="skill.title"
       class='mb-2'
     )
     A-BodyText(:content='skill.description' class='max-w-[277px] mb-0')
@@ -21,10 +21,10 @@ export default {
     skill: {
       required: true,
       type: Object,
-      logos: {
+      tags: {
         type: Array,
       },
-      heading: {
+      title: {
         type: String,
       },
       description: {

--- a/components/organisms/SkillList.vue
+++ b/components/organisms/SkillList.vue
@@ -8,52 +8,16 @@
       M-SkillCard(:skill='skill')
 </template>
 <script>
+import { useAsync, useContext } from '@nuxtjs/composition-api';
 export default {
   setup() {
-    const skills = [
-      {
-        logos: ['universal-access'],
-        heading: 'Web Accessibility',
-        description:
-          'Attention to detail with the use of the NVDA screen reader to test interactions with web pages and components. This is essential for universal usuability and design.',
-      },
-      {
-        logos: ['react'],
-        heading: 'Quick Building With React',
-        description:
-          'With my fundamental knowledge of React and the Gatsby framework, they can provide high usability to your complex project.',
-      },
-      {
-        logos: ['vuejs', 'nuxt'],
-        heading: 'Or Maybe You Prefer Vue?',
-        description:
-          'Vue can provide you a lighter load for a smaller application.<br/> <strong>(This very site is built in NuxtJS!)</strong>',
-      },
-      {
-        logos: ['sass'],
-        heading: 'Preprocessing with SASS',
-        description:
-          'This matters in making stylesheet creation programmatic . . . Which means fast building and scaling of the design!',
-      },
-      {
-        logos: ['tailwindcss', 'bootstrap'],
-        heading: 'CSS Frameworks',
-        description:
-          'Knowledge with Bootstrap and TailwindCSS to provide quick UI layouts and Utility styling. <br /> <strong>(This site implements TailwindCSS)</strong>',
-      },
-      {
-        logos: ['html', 'css', 'js'],
-        heading: "Don't Forget the Basics!",
-        description: 'Proficient in HTML, CSS, and JavaScript. Simple.',
-      },
-      {
-        logos: ['laptop-code'],
-        heading: 'Code Review',
-        description:
-          "It's just as important to keep attention to detail on a team to ensure everyone succeeds!",
-      },
-    ];
-
+    const { $content } = useContext();
+    const skills = useAsync(() => {
+      return $content('skills')
+        .only(['display-order', 'title', 'description', 'tags'])
+        .sortBy('display-order', 'asc')
+        .fetch();
+    });
     return { skills };
   },
 };

--- a/content/skills/code-review.md
+++ b/content/skills/code-review.md
@@ -1,0 +1,8 @@
+---
+layout: skills
+display-order: 7
+title: Code Review
+description: "It's just as important to keep attention to detail on a team to ensure everyone succeeds!"
+tags:
+  - laptop-code
+---

--- a/content/skills/css-frameworks.md
+++ b/content/skills/css-frameworks.md
@@ -1,0 +1,9 @@
+---
+layout: skills
+display-order: 5
+title: CSS Frameworks
+description: 'Knowledge with Bootstrap and TailwindCSS to provide quick UI layouts and Utility styling.<br /><strong>(This site implements TailwindCSS)</strong>'
+tags:
+  - tailwindcss
+  - bootstrap
+---

--- a/content/skills/dont-forget-the-basics.md
+++ b/content/skills/dont-forget-the-basics.md
@@ -1,0 +1,10 @@
+---
+layout: skills
+display-order: 6
+title: Don't Forget the Basics!
+description: 'Proficient in HTML, CSS, and JavaScript. Simple.'
+tags:
+  - html
+  - css
+  - js
+---

--- a/content/skills/or-maybe-you-prefer-vue.md
+++ b/content/skills/or-maybe-you-prefer-vue.md
@@ -1,0 +1,10 @@
+---
+layout: skills
+display-order: 3
+title: Or Maybe You Prefer Vue?
+description: 'Vue can provide you a lighter load for a smaller application.<br />
+<strong>(This very site is built in NuxtJS!)</strong>'
+tags:
+  - vuejs
+  - nuxt
+---

--- a/content/skills/preprocessing-with-sass.md
+++ b/content/skills/preprocessing-with-sass.md
@@ -1,0 +1,8 @@
+---
+layout: skills
+display-order: 4
+title: Preprocessing with SASS
+description: 'This matters in making stylesheet creation programmatic . . . Which means fast building and scaling of the design!'
+tags:
+  - sass
+---

--- a/content/skills/quick-building-with-react.md
+++ b/content/skills/quick-building-with-react.md
@@ -1,0 +1,9 @@
+---
+layout: skills
+display-order: 2
+title: Quick Building With React
+description: 'With my fundamental knowledge of React and the Gatsby framework, they can provide high usability to your complex project.'
+tags:
+  - react
+  - gatsby
+---

--- a/content/skills/web-accessibility.md
+++ b/content/skills/web-accessibility.md
@@ -1,0 +1,8 @@
+---
+layout: skills
+display-order: 1
+title: Web Accessibility
+description: 'Attention to detail with the use of the NVDA screen reader to test interactions with web pages and components. This is essential for universal usuability and design.'
+tags:
+  - universal-access
+---

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -29,3 +29,20 @@ collections:
           widget: 'list',
           hint: 'Use only the following in lowercase: bootstrap, codepen, css, gatsby, html, js, linkedin, nuxt, react, sass, tailwindcss, twitter, vuejs',
         }
+  - name: 'skills'
+    label: 'Skills'
+    folder: 'content/skills'
+    format: 'frontmatter'
+    create: true
+    preview_path: '/'
+    fields: # The fields for each document, usually in front matter
+      - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'skills' }
+      - { label: 'Display Order', name: 'display-order', widget: 'number' }
+      - { label: 'Title', name: 'title', widget: 'string' }
+      - { label: 'Description', name: 'description', widget: 'text' }
+      - {
+          label: 'Skill Logos',
+          name: 'skill-logos',
+          widget: 'list',
+          hint: 'Available labels: universal-access, react, gatsby, vuejs, nuxt, sass, tailwindcss, bootstrap, html, css, js, laptop-code',
+        }


### PR DESCRIPTION
This request is to render the content of the "Skills" section via markdown down files that can be edited by the Netlify CMS and handled by the Nuxt Content API plugin.

This is allows for more control in updating this list, such as adding content item points, icons for visual of skills added, etc.

This request also adds the Chakra UI icon for use in both this section and the projects list.

Closes #18 